### PR TITLE
Change header logic to only check for profile image once per initialization

### DIFF
--- a/apps/front/src/app/header/header.component.ts
+++ b/apps/front/src/app/header/header.component.ts
@@ -114,7 +114,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy {
           const user = await this.usersService.myUser();
           if (user) this.user = user;
 
-          await this.viewAvatar();
           this.profilePictureModal.updateAvatarEvent.subscribe(async () => await this.viewAvatar());
         }
       }
@@ -146,6 +145,8 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.cookieService.get("authenticated")) {
       this.signedIn = true;
     }
+
+    if (this.signedIn && !this.hidden) await this.viewAvatar();
 
     // Hide modals when the route changes
     this.router.events.subscribe(() => this.modalRef?.hide());


### PR DESCRIPTION
Fixes #59 

Overcomplicated to _only_ request the image if the user is guaranteed to have one - a field for the user model would have to be added and then checked once per initialization. Easier to check with a simple request - it isn't blocking, and it's only one 404 per visit if the user does not have one.