### PR TITLE
Implement cursor auto-positioning at end of term field on modal open

### DIFF
--- a/apps/front/src/app/shared/card/card.component.html
+++ b/apps/front/src/app/shared/card/card.component.html
@@ -37,7 +37,7 @@
       <div class="row row-cols-1 row-cols-md-2">
         <div class="col border-end">
           <p class="fs-2">Term</p>
-          <quill-editor [(ngModel)]="changingTerm" (ngModelChange)="editCardEvent.emit()" id="termEditor" class="w-100"></quill-editor>
+          <quill-editor (onEditorCreated)="focusEditor($event)" [(ngModel)]="changingTerm" (ngModelChange)="editCardEvent.emit()" id="termEditor" class="w-100"></quill-editor>
         </div>
         <div class="col mt-4 mt-md-0">
           <p class="fs-2 pull-right">Definition</p>

--- a/apps/front/src/app/shared/card/card.component.ts
+++ b/apps/front/src/app/shared/card/card.component.ts
@@ -16,6 +16,7 @@ import { BsModalRef, BsModalService } from "ngx-bootstrap/modal";
 import { DomSanitizer } from "@angular/platform-browser";
 import { ViewportScroller } from "@angular/common";
 import { DeviceDetectorService } from "ngx-device-detector";
+import Quill from "quill";
 
 @Component({
   selector: "scholarsome-card",
@@ -152,5 +153,10 @@ export class CardComponent implements OnInit, AfterViewInit {
 
   moveCard(direction: number) {
     this.moveCardEvent.emit({ index: this.cardIndex, direction });
+  }
+
+  // Set cursor position to end
+  focusEditor($event: Quill) {
+    $event.setSelection($event.getLength(), 0);
   }
 }


### PR DESCRIPTION
## Changes
- Implemented a function in the modal's component script that triggers when the modal is shown. This function sets the cursor position to the end of the content specifically in the 'term' field of the modal used for adding or updating cards.
- Updated the initialization process of the modal to integrate the new cursor positioning logic, ensuring that it activates every time the modal is opened for either adding a new card or updating an existing one.
