### PR TITLE
fix docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /usr/src/app
 
 RUN apk add g++ make py3-pip
 
-COPY package*.json .
-RUN npm install --omit=dev --legacy-peer-deps --ignore-scripts --platform=linuxmusl
+COPY package*.json ./
+RUN npm install --legacy-peer-deps --ignore-scripts --platform=linuxmusl
 RUN npm rebuild bcrypt --build-from-source
 RUN npm rebuild sharp --build-from-source
 

--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ services:
   redis:
     image: redis:latest
     expose:
-      - "6379:6379"
+      - "6379"
     command: >
       redis-server
       --save 900 1
@@ -17,7 +17,7 @@ services:
   mariadb:
     image: mariadb:latest
     expose:
-      - "3306:3306"
+      - "3306"
     environment:
       - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
       - "MARIADB_ROOT_HOST=localhost"


### PR DESCRIPTION

**Expose Syntax**
The Docker documentation specifies the syntax for EXPOSE, which is more appropriate.

**Remove Omit Flag**
In step 10, an error occurred during the build process because the omit flag prevents the installation of the quill library, which is listed in devDependencies.

![2](https://github.com/user-attachments/assets/f282ff21-49a1-4015-81be-9513fdcef521)
